### PR TITLE
Documentation fix: clirrRootReport must consider enabled

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -67,7 +67,7 @@ to generate an aggregate clirr report
 ----
 task clirrRootReport(type: org.kordamp.gradle.clirr.ClirrReportTask) {
     dependsOn = subprojects.tasks.clirr
-    reports = files(subprojects.tasks.clirr.xmlReport)
+    reports = files((subprojects.findAll { it.clirr.enabled == true }).tasks.clirr.xmlReport)
 }
 ----
 


### PR DESCRIPTION
As otherwhise the subproject clirr task will not generate a report file,
which is causing the ClirrReportTask to fail.

This looks rather ugly. But the only other option I can think of is making ClirrReportTask to ignore missing reports, which doesn't seem to be the right approach to tackle this.