### PR TITLE
Support .* suffix for package names

### DIFF
--- a/src/main/groovy/org/kordamp/gradle/clirr/BufferedListener.java
+++ b/src/main/groovy/org/kordamp/gradle/clirr/BufferedListener.java
@@ -60,6 +60,20 @@ public class BufferedListener extends DiffListenerAdapter {
             return;
         }
 
+        // Check for .* suffix on each package name
+        for (final String ignoredPackage : ignoredPackages) {
+            if (ignoredPackage.endsWith(".*")) {
+                // Ignore any sub-package of the prefix
+                if (packageName.startsWith(ignoredPackage.substring(0, ignoredPackage.length() - 1))) {
+                    return;
+                }
+                // Ignore the prefix itself
+                if (packageName.equals(ignoredPackage.substring(0, ignoredPackage.length() - 2))) {
+                    return;
+                }
+            }
+        }
+
         final String memberName = extractMemberName(difference);
 
         if (memberName != null


### PR DESCRIPTION
Allows for global package exclusions, rather than having to list each individually.

Port of trnl/clirr-gradle-plugin#3 by @jyemin

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/aalmiray/clirr-gradle-plugin/8)

<!-- Reviewable:end -->
